### PR TITLE
Fix ePADlite ReferenceError mariadb_log is not defined

### DIFF
--- a/.originals/production_epadlite.js
+++ b/.originals/production_epadlite.js
@@ -15,7 +15,7 @@ module.exports = {
     port: "3306",
     user: "{mariadb_user}",
     pass: "{mariadb_password}",
-    logger: { mariadb_log },
+    logger: "{mariadb_log}",
   },
   ontologyName: "{ontologyname}",
   ontologyApiKey: "{ontologyapikey}",


### PR DESCRIPTION
On `docker-compose up -d`, the epad_lite server fails to start due to `ReferenceError: mariadb_log is not defined`. This can be fixed in production_epadlite.js by either removing the logger entry or changing it from a nested object to a string entry.